### PR TITLE
Bump versions for lens-family-core & optparse-app.

### DIFF
--- a/morte.cabal
+++ b/morte.cabal
@@ -1,5 +1,5 @@
 Name: morte
-Version: 1.1.0
+Version: 1.1.1
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3

--- a/morte.cabal
+++ b/morte.cabal
@@ -32,13 +32,13 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base                 >= 4        && < 5   ,
-        array                >= 0.4.0.0  && < 0.6 ,
-        binary                              < 0.8 ,
-        lens-family-core     >= 1.0.0    && < 1.2 ,
-        pipes                >= 4.0.0    && < 4.2 ,
-        text                 >= 0.11.1.0 && < 1.3 ,
-        transformers         >= 0.2.0.0  && < 0.5
+        base                 >= 4        && <  5     ,
+        array                >= 0.4.0.0  && <  0.6   ,
+        binary                              <  0.8   ,
+        lens-family-core     >= 1.0.0    && <= 1.2.0 ,
+        pipes                >= 4.0.0    && <  4.2   ,
+        text                 >= 0.11.1.0 && <  1.3   ,
+        transformers         >= 0.2.0.0  && <  0.5
     Exposed-Modules:
         Morte.Core,
         Morte.Lexer,
@@ -51,7 +51,7 @@ Executable morte
     Hs-Source-Dirs: exec
     Main-Is: Main.hs
     Build-Depends:
-        base                 >= 4        && < 5   ,
-        morte                                     ,
-        optparse-applicative                < 0.11,
-        text                 >= 0.11.1.0 && < 1.3
+        base                 >= 4        && <  5        ,
+        morte                                           ,
+        optparse-applicative                <= 0.11.0.1 ,
+        text                 >= 0.11.1.0 && <  1.3


### PR DESCRIPTION
Bumped versions of lens-family-core and optparse-applicative. Program compiled but there didn't seem to be any tests. I will be working with it a bit today so I can let you know if I hit any issues.