### PR TITLE
Add NFData instances for Morte core types.

### DIFF
--- a/morte.cabal
+++ b/morte.cabal
@@ -35,6 +35,7 @@ Library
         base                 >= 4        && <  5     ,
         array                >= 0.4.0.0  && <  0.6   ,
         binary                              <  0.8   ,
+        deepseq              >= 1.3.0    && <  1.5   ,
         lens-family-core     >= 1.0.0    && <  1.3.0 ,
         pipes                >= 4.0.0    && <  4.2   ,
         text                 >= 0.11.1.0 && <  1.3   ,


### PR DESCRIPTION
I'm in the midst of writing benchmarks and was in need of these instances.
Using `Generic` in order to derive the instances automatically needs a `base` version bump to 4.6, if that's not ok with you I'll write the `NFData` instances manually and amend the commit. 