### PR TITLE
Add basic public API benchmarks on *.mt source files.

### DIFF
--- a/benchmarks/Bench.hs
+++ b/benchmarks/Bench.hs
@@ -1,0 +1,53 @@
+module Main (main) where
+
+import Morte.Core
+import Morte.Parser (ParseError, exprFromText, prettyParseError)
+
+import Criterion.Main    (Benchmark, defaultMain, env, bgroup, bench, nf)
+import Data.Text.Lazy    (Text)
+import qualified Data.Text.Lazy as T
+import Data.Text.Lazy.IO (readFile, hPutStrLn)
+import GHC.IO.Handle.FD  (stderr)
+import Paths_morte       (getDataFileName)
+import Prelude hiding    (readFile)
+
+benchFilenames :: [String]
+benchFilenames = [
+      "recursive.mt"
+    , "factorial.mt"
+    ]
+
+readMtFile :: String -> IO (String, Text)
+readMtFile filename = do
+    path   <- getDataFileName filename
+    mtFile <- readFile path
+    return (filename, mtFile)
+
+partitionExpr :: (String, Text) -> ([(String, ParseError)],[(String, Expr)])
+              -> ([(String, ParseError)],[(String, Expr)])
+partitionExpr (filename, contents) (pe,ps) =
+    case exprFromText contents of
+        Left  perr -> ((filename,perr):pe,ps)
+        Right expr -> (pe,(filename,expr):ps)
+
+pprFileParseError :: (String, ParseError) -> Text
+pprFileParseError (fn,pe) = T.unlines [T.pack fn, prettyParseError pe]
+
+srcEnv :: IO [(String, Expr)]
+srcEnv = do
+    mtFiles <- mapM readMtFile benchFilenames
+    let (pe,ps) = foldr partitionExpr ([],[]) mtFiles
+    mapM_ (hPutStrLn stderr . pprFileParseError) pe
+    return ps
+
+main :: IO ()
+main = defaultMain [
+      env srcEnv $ bgroup "source" . map benchExpr
+    ]
+
+benchExpr :: (String, Expr) -> Benchmark
+benchExpr (tag,expr) = bgroup tag [
+      bench "normalize" $ nf normalize expr
+    , bench "equality"  $ nf (expr ==) expr
+    , bench "typeOf"    $ nf typeOf    expr
+    ]

--- a/benchmarks/src/factorial.mt
+++ b/benchmarks/src/factorial.mt
@@ -1,0 +1,99 @@
+(  \(Nat : *)
+-> \(Succ : Nat -> Nat)
+-> \(Zero : Nat)
+-> \(mult : Nat -> Nat -> Nat)
+-> \(foldNat : Nat -> forall (r : *) -> (r -> r) -> r -> r)
+-> \(Pair : * -> *)
+-> \(_P    : forall (a : *) -> a -> a -> Pair a)
+-> \(_fst  : forall (a : *) -> Pair a -> a)
+-> \(_snd  : forall (a : *) -> Pair a -> a)
+-> (  \(NPair : *)
+   -> \(P : Nat -> Nat -> NPair)
+   -> \(fst : NPair -> Nat)
+   -> \(snd : NPair -> Nat)
+   -> \(mi  : Nat)
+   -> \(n : Nat)
+   -> (  \(pfact : NPair -> NPair) 
+      -> snd (foldNat n NPair pfact (P Zero mi))
+      )
+
+      (  \(p : NPair)
+      -> (\(sfp : Nat) -> P sfp (mult (snd p) sfp)) (Succ (fst p))
+      )
+   )
+
+  -- NPair
+  (Pair Nat)
+
+  -- P
+  (_P Nat)
+
+  -- fst
+  (_fst Nat)
+
+  -- snd
+  (_snd Nat)
+
+  -- multiplicative identity
+  (Succ Zero)
+
+  -- 7
+  (Succ (Succ (Succ (Succ (Succ (Succ (Succ Zero)))))))
+
+)
+
+-- Nat
+(forall (nat : *) -> (nat -> nat) -> nat -> nat)
+
+-- Succ data constructor
+(  \(n : forall (nat : *) -> (nat -> nat) -> nat -> nat)
+-> \(nat : *)
+-> \(Succ : nat -> nat)
+-> \(Zero : nat)
+-> Succ (n nat Succ Zero)
+)
+
+-- Zero data constructor
+(  \(nat : *)
+-> \(Succ : nat -> nat)
+-> \(Zero : nat)
+-> Zero
+)
+
+-- mult
+(  \(a : |~| (nat : *) -> (nat -> nat) -> nat -> nat)
+-> \(b : forall (nat : *) -> (nat -> nat) -> nat -> nat)
+-> \(nat : *)
+-> \(Succ : nat -> nat)
+-> \(Zero : nat)
+-> (a nat) (b nat Succ) Zero
+)
+
+-- foldNat
+(  \(n : forall (r : *) -> (r -> r) -> r -> r)
+-> n
+)
+
+-- MonoPair
+(\(a : *) -> forall (r : *) -> (a -> a -> r) -> r)
+
+-- P
+(  \(a : *)
+-> \(va : a)
+-> \(vb : a)
+-> \(r : *)
+-> \(Pair : a -> a -> r)
+-> Pair va vb
+)
+
+-- fst
+(  \(a : *)
+-> \(p : forall (r : *) -> (a -> a -> r) -> r)
+-> p a (\(x : a) -> \(_ : a) -> x)
+)
+
+-- snd
+(  \(a : *)
+-> \(p : forall (r : *) -> (a -> a -> r) -> r)
+-> p a (\(_ : a) -> \(x : a) -> x)
+)

--- a/benchmarks/src/recursive.mt
+++ b/benchmarks/src/recursive.mt
@@ -1,0 +1,186 @@
+-- "Free" variables
+(   \(String : *   )
+->  \(U : *)
+->  \(Unit : U)
+
+    -- Simple prelude
+->  (   \(Nat : *)
+    ->  \(zero : Nat)
+    ->  \(one : Nat)
+    ->  \((+) : Nat -> Nat -> Nat)
+    ->  \((*) : Nat -> Nat -> Nat)
+    ->  \(foldNat : Nat -> forall (a : *) -> (a -> a) -> a -> a)
+    ->  \(IO : * -> *)
+    ->  \(return : forall (a : *) -> a -> IO a)
+    ->  \((>>=)
+        :   forall (a : *)
+        ->  forall (b : *)
+        ->  IO a
+        ->  (a -> IO b)
+        ->  IO b
+        )
+    ->  \(putStrLn : String -> IO U)
+    ->  \(getLine : IO String)
+
+        -- Derived functions
+    ->  (   \((>>) : IO U -> IO U -> IO U)
+        ->  \(two   : Nat)
+        ->  \(three : Nat)
+        ->  \(four  : Nat)
+        ->  \(five  : Nat)
+        ->  \(six   : Nat)
+        ->  \(seven : Nat)
+        ->  \(eight : Nat)
+        ->  \(nine  : Nat)
+        ->  \(ten   : Nat)
+        ->  (   \(replicateM_ : Nat -> IO U -> IO U)
+            ->  \(ninetynine : Nat)
+            ->  replicateM_ ninetynine ((>>=) String U getLine putStrLn)
+            )
+
+            -- replicateM_
+            (   \(n : Nat)
+            ->  \(io : IO U)
+            ->  foldNat n (IO U) ((>>) io) (return U Unit)
+            )
+
+            -- ninetynine
+            ((+) ((*) nine ten) nine)
+        )
+
+        -- (>>)
+        (   \(m : IO U)
+        ->  \(n : IO U)
+        ->  (>>=) U U m (\(_ : U) -> n)
+        )
+
+        -- two
+        ((+) one one)
+
+        -- three
+        ((+) one ((+) one one))
+
+        -- four
+        ((+) one ((+) one ((+) one one)))
+
+        -- five
+        ((+) one ((+) one ((+) one ((+) one one))))
+
+        -- six
+        ((+) one ((+) one ((+) one ((+) one ((+) one one)))))
+
+        -- seven
+        ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one one))))))
+
+        -- eight
+        ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one one)))))))
+        -- nine
+        ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one one))))))))
+
+        -- ten
+        ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one ((+) one one)))))))))
+    )
+
+    -- Nat
+    (   forall (a : *)
+    ->  (a -> a)
+    ->  a
+    ->  a
+    )
+
+    -- zero
+    (   \(a : *)
+    ->  \(Succ : a -> a)
+    ->  \(Zero : a)
+    ->  Zero
+    )
+
+    -- one
+    (   \(a : *)
+    ->  \(Succ : a -> a)
+    ->  \(Zero : a)
+    ->  Succ Zero
+    )
+
+    -- (+)
+    (   \(m : forall (a : *) -> (a -> a) -> a -> a)
+    ->  \(n : forall (a : *) -> (a -> a) -> a -> a)
+    ->  \(a : *)
+    ->  \(Succ : a -> a)
+    ->  \(Zero : a)
+    ->  m a Succ (n a Succ Zero)
+    )
+
+    -- (*)
+    (   \(m : forall (a : *) -> (a -> a) -> a -> a)
+    ->  \(n : forall (a : *) -> (a -> a) -> a -> a)
+    ->  \(a : *)
+    ->  \(Succ : a -> a)
+    ->  \(Zero : a)
+    ->  m a (n a Succ) Zero
+    )
+
+    -- foldNat
+    (   \(n : forall (a : *) -> (a -> a) -> a -> a)
+    ->  n
+    )
+
+    -- IO
+    (   \(r : *)
+    ->  forall (x : *)
+    ->  (String -> x -> x)
+    ->  ((String -> x) -> x)
+    ->  (r -> x)
+    ->  x
+    )
+
+    -- return
+    (   \(a : *)
+    ->  \(va : a)
+    ->  \(x : *)
+    ->  \(PutStrLn : String -> x -> x)
+    ->  \(GetLine : (String -> x) -> x)
+    ->  \(Return : a -> x)
+    ->  Return va
+    )
+
+    -- (>>=)
+    (   \(a : *)
+    ->  \(b : *)
+    ->  \(m : forall (x : *)
+        ->  (String -> x -> x)
+        ->  ((String -> x) -> x)
+        ->  (a -> x)
+        ->  x
+        )
+    ->  \(f : a
+        ->  forall (x : *)
+        -> (String -> x -> x)
+        -> ((String -> x) -> x)
+        -> (b -> x)
+        -> x
+        )
+    ->  \(x : *)
+    ->  \(PutStrLn : String -> x -> x)
+    ->  \(GetLine : (String -> x) -> x)
+    ->  \(Return : b -> x)
+    ->  m x PutStrLn GetLine (\(va : a) -> f va x PutStrLn GetLine Return)
+    )
+
+    -- putStrLn
+    (   \(str : String)
+    ->  \(x : *)
+    ->  \(PutStrLn : String -> x -> x  )
+    ->  \(GetLine  : (String -> x) -> x)
+    ->  \(Return   : U -> x)
+    ->  PutStrLn str (Return Unit)
+    )
+
+    -- getLine
+    (   \(x : *)
+    ->  \(PutStrLn : String -> x -> x  )
+    ->  \(GetLine  : (String -> x) -> x)
+    ->  \(Return   : String -> x)
+    -> GetLine Return
+    )
+)

--- a/morte.cabal
+++ b/morte.cabal
@@ -25,6 +25,8 @@ Description: Morte is a typed, purely functional, and strongly normalizing
     .
     Read "Morte.Tutorial" to learn how to use this library
 Category: Compiler
+Data-Dir: benchmarks/src
+Data-Files: *.mt
 Source-Repository head
     Type: git
     Location: https://github.com/Gabriel439/Haskell-Morte-Library
@@ -56,3 +58,15 @@ Executable morte
         morte                                           ,
         optparse-applicative                <= 0.11.0.1 ,
         text                 >= 0.11.1.0 && <  1.3
+
+Benchmark benchmarks
+    Type:           exitcode-stdio-1.0
+    HS-Source-Dirs: benchmarks
+    Main-Is:        Bench.hs
+    GHC-Options:    -O2 -Wall
+
+    Build-Depends:
+        base      >= 4        && < 5    ,
+        criterion                < 1.1  ,
+        morte     >= 1.1.0              ,
+        text      >= 0.11.1.0 && <  1.3

--- a/src/Morte/Core.hs
+++ b/src/Morte/Core.hs
@@ -302,6 +302,15 @@ data TypeMessage
     | Untyped Const
     deriving (Show)
 
+instance NFData TypeMessage where
+    rnf tm = case tm of
+        UnboundVariable     -> ()
+        InvalidInputType e  -> rnf e
+        InvalidOutputType e -> rnf e
+        NotAFunction        -> ()
+        TypeMismatch e1 e2  -> rnf e1 `seq` rnf e2
+        Untyped c           -> rnf c
+
 -- | A structured type error that includes context
 data TypeError = TypeError
     { context     :: Context
@@ -313,6 +322,9 @@ instance Show TypeError where
     show = unpack . prettyTypeError
 
 instance Exception TypeError
+
+instance NFData TypeError where
+    rnf (TypeError ctx crr tym) = rnf ctx `seq` rnf crr `seq` rnf tym
 
 -- | Render a pretty-printed `Const` as a `Builder`
 buildConst :: Const -> Builder


### PR DESCRIPTION
These are some basic benchmarks for `normalize`, `typeOf` and the `Eq` instance, so only the API that `Core.hs` exports.
The benchmarks are done by parsing `recursive.mt` found in the tutorial and `factorial.mt`.
If it's all ok and before moving forward with adding new benchmarks I'd like it if we can discuss more about:
  - Moving `Morte.Core` into something like `Morte.Internal.Core` where everything is exported so that we cand benchmark and test every component,
    and make `Morte.Core` just reexport what should pe public API. Or anything that allows us to do this.
  - Writing an benchmarking on `*.mt` is not really feasible for all kinds of benchmarks. We should be able to generate expressions in a deterministic manner and what
    I'm interested in this case is at what level of control do you think we should do it ? Should we be able to control all of depth, free variables, number of Pi terms, Lambda terms, applications      parameters ? I'm wondering if you think this would be overkill and time better spent on something else.