### PR TITLE
7.10 migration: override default NFData implemtation

### DIFF
--- a/src/Morte/Core.hs
+++ b/src/Morte/Core.hs
@@ -172,7 +172,8 @@ instance Binary Const where
             1 -> return Box
             _ -> fail "get Const: Invalid tag byte"
 
-instance NFData Const
+instance NFData Const where
+    rnf c = seq c ()
 
 axiom :: Const -> Either TypeError Const
 axiom Star = return Box


### PR DESCRIPTION
Simple change needed to build with 7.10. https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10#deepseq-1.4.0.0deepseq-1.4.1.0