### PR TITLE
7.10 migration: Override default NFData implemtation for newtype X

### DIFF
--- a/src/Morte/Core.hs
+++ b/src/Morte/Core.hs
@@ -212,7 +212,8 @@ instance Eq X where
 instance Show X where
     show = absurd
 
-instance NFData X
+instance NFData X where
+    rnf x = seq x ()
 
 -- | Syntax tree for expressions
 data Expr a


### PR DESCRIPTION
The simple travis configuration present in the repo at the moment only builds agains GHC 7.6.3, how do you feel about configuring it to build against all versions from 7.6.3 to HEAD in order to catch these kinds of problems ?