### PR TITLE
Use Data.Void from base

### DIFF
--- a/morte.cabal
+++ b/morte.cabal
@@ -50,7 +50,7 @@ Library
         system-filepath    >= 0.3.1    && < 0.5  ,
         system-fileio      >= 0.2.1    && < 0.4  ,
         text               >= 0.11.1.0 && < 1.3  ,
-        text-format                       < 0.4  ,
+        text-format        >= 0.3.1.1  && < 0.4  ,
         transformers       >= 0.2.0.0  && < 0.5
     Exposed-Modules:
         Morte.Core,

--- a/src/Morte/Import.hs
+++ b/src/Morte/Import.hs
@@ -87,6 +87,7 @@ import Data.Text.Lazy.Builder (Builder)
 import qualified Data.Text.Lazy.Builder as Builder
 import Data.Traversable (traverse)
 import Data.Typeable (Typeable)
+import Data.Void (Void, absurd)
 import Filesystem.Path ((</>))
 import Filesystem as Filesystem
 import Lens.Micro (Lens')
@@ -96,7 +97,7 @@ import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Client.TLS as HTTP
 import Prelude hiding (FilePath)
 
-import Morte.Core (Expr, Path(..), X(..), typeOf)
+import Morte.Core (Expr, Path(..), typeOf)
 import Morte.Parser (exprFromText)
 
 builderToString :: Builder -> String
@@ -166,14 +167,14 @@ instance Show e => Show (Imported e) where
 
 data Status = Status
     { _stack   :: [Path]
-    , _cache   :: Map Path (Expr X)
+    , _cache   :: Map Path (Expr Void)
     , _manager :: Maybe Manager
     }
 
 stack :: Lens' Status [Path]
 stack k s = fmap (\x -> s { _stack = x }) (k (_stack s))
 
-cache :: Lens' Status (Map Path (Expr X))
+cache :: Lens' Status (Map Path (Expr Void))
 cache k s = fmap (\x -> s { _cache = x }) (k (_cache s))
 
 manager :: Lens' Status (Maybe Manager)
@@ -247,7 +248,7 @@ loadDynamic p = do
         Right expr -> return expr 
 
 -- | Load a `Path` as a \"static\" expression (with all imports resolved)
-loadStatic :: Path -> StateT Status Managed (Expr X)
+loadStatic :: Path -> StateT Status Managed (Expr Void)
 loadStatic path = do
     paths <- zoom stack get
 
@@ -290,7 +291,7 @@ loadStatic path = do
     return expr
 
 -- | Resolve all imports within an expression
-load :: Expr Path -> IO (Expr X)
+load :: Expr Path -> IO (Expr Void)
 load expr =
     with (evalStateT (fmap join (traverse loadStatic expr)) status) return
   where

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,8 @@
 flags: {}
 packages:
 - '.'
+- location:
+    git: git@github.com:bos/text-format.git
+    commit: abc3862f893bfcd0841c2cda9100acdc89a15614
 extra-deps: []
-resolver: nightly-2015-11-22
+resolver: lts-5.1


### PR DESCRIPTION
closes #16 

**TODO:** proper `text-format` lower dependency (for the `Buildable Void` instance). It will be possible as soon as the next version of `text-format` is released (the necessary changes are already merged upstream). As a temporary workaround I put the git repo as the source for building `text-format` into `stack.yaml`.

This PR probably shouldn't be merged into `master` yet because of this workaround, but I'll open it anyway because I'm going to base my further work on this.
