### PR TITLE
Added IPFS hash functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ further simplify Morte code, but this is not urgent and definitely a lower
 priority than implementing front-end and back-end compilers.  If implemented,
 this would be entirely backwards compatible.
 
+## IPFS
+
+There is a morte-[IPFS](https://ipfs.io) bridge being built at the 
+[´ipfs´](https://github.com/Gabriel439/Haskell-Morte-Library/tree/ipfs) branch.
+It is not yet fully tested but provides type-checking, normalizing,
+and displaying a Morte program read from an IPFS address or hash.
+
 ## Regenerating .travis.yml
 
 Using https://github.com/hvr/multi-ghc-travis

--- a/exec/Ipfs.hs
+++ b/exec/Ipfs.hs
@@ -53,9 +53,10 @@ main = do
         <>  progDesc "Type-check, normalize, and display a Morte program read \
                      \from an IPFS address or hash."
         )
-    if isInfixOf "/ipfs/" address 
-        then let expr = Embed (URL ("http://" ++ host ++ ":" ++ port ++ address))
-        else let expr = Embed (URL ("http://" ++ host ++ ":" ++ port ++ "/ipfs/" ++ address))
+    let expr = if isInfixOf "/ipfs/" address 
+                then Embed (URL ("http://" ++ host ++ ":" ++ port ++ address))
+                else Embed (URL ("http://" ++ host ++ ":" ++ port ++ "/ipfs/" ++ address))
+    in
     expr'    <- load expr
     typeExpr <- throws (typeOf expr')
     Text.hPutStrLn stderr (pretty (normalize typeExpr))

--- a/exec/Ipfs.hs
+++ b/exec/Ipfs.hs
@@ -3,6 +3,7 @@ module Main where
 import Control.Exception (Exception, throwIO)
 import Data.Monoid (mempty)
 import qualified Data.Text.Lazy.IO as Text
+import Data.List (isInfixOf)
 import Morte.Core (Expr(..), Path(..), typeOf, pretty, normalize)
 import Options.Applicative hiding (Const)
 import System.IO (stderr)
@@ -25,14 +26,14 @@ parser =
         Options
     <$> strArgument
         (   metavar "ADDRESS"
-        <>  help "An IPFS address pointing to a Morte expression"
+        <>  help "An IPFS address or hash pointing to a Morte expression"
         )
     <*> strOption
         (   long "host"
         <>  short 'h'
         <>  metavar "HOST"
         <>  help "The IPFS gateway server"
-        <>  value "ipfs.io"
+        <>  value "gateway.ipfs.io"
         <>  showDefaultWith id
         )
     <*> strOption
@@ -50,9 +51,11 @@ main = do
         (   fullDesc
         <>  header "morte-ipfs - Invoke `morte` on a given IPFS address"
         <>  progDesc "Type-check, normalize, and display a Morte program read \
-                     \from an IPFS address."
+                     \from an IPFS address or hash."
         )
-    let expr = Embed (URL ("http://" ++ host ++ ":" ++ port ++ "/" ++ address))
+    if isInfixOf "/ipfs/" address 
+        then let expr = Embed (URL ("http://" ++ host ++ ":" ++ port ++ address))
+        else let expr = Embed (URL ("http://" ++ host ++ ":" ++ port ++ "/ipfs/" ++ address))
     expr'    <- load expr
     typeExpr <- throws (typeOf expr')
     Text.hPutStrLn stderr (pretty (normalize typeExpr))


### PR DESCRIPTION
Hi. I'm new to Haskell but know some basics, so I (hopefully successfully) fixed/added the IPFS hash functionality, so that now `/ipfs/<hash>` and also `<hash>` alone are supported. Also, I added an IPFS section in README.

I hope it helps.