### PR TITLE
Add basic Arbitrary instance and property tests.

### DIFF
--- a/morte.cabal
+++ b/morte.cabal
@@ -81,3 +81,18 @@ Benchmark benchmarks
         criterion >= 1.0.0.1  && < 1.2,
         morte                         ,
         text      >= 0.11.1.0 && < 1.3
+
+Test-Suite properties
+    Type:           exitcode-stdio-1.0
+    HS-Source-Dirs: testsuite
+    Main-Is:        Properties.hs
+    GHC-Options:    -O2 -Wall 
+
+    Build-Depends:
+        base       >= 4        && < 5  ,
+        mtl        >= 2.2      && < 2.3,
+        tasty      >= 0.11             ,
+        QuickCheck >= 2.8.1            ,
+        tasty-quickcheck >= 0.8.4      ,
+        morte                          ,
+        text       >= 0.11.1.0 && < 1.3

--- a/testsuite/ClosedWellTyped.hs
+++ b/testsuite/ClosedWellTyped.hs
@@ -1,0 +1,150 @@
+module ClosedWellTyped (
+    ClosedWellTyped(..)
+    ) where
+
+import Control.Applicative as A ((<$>))
+import Control.Monad.State.Lazy
+import Data.Text.Lazy (Text, pack)
+import Test.QuickCheck
+
+import Morte.Core
+
+
+newtype ClosedWellTyped = ClosedWellTyped { unClosedWellTyped :: Expr X }
+    deriving Show
+
+data Env a = Env {
+      bindings :: [(Var, Expr a)]
+    , uniques  :: [Text]
+    }
+
+type GenExpr e a   = StateT (Env e) Gen a
+type GenExprPair e = StateT (Env e) Gen (Expr e,Expr e)
+
+instance Arbitrary ClosedWellTyped where
+    arbitrary = sized rndExpr
+
+
+rndExpr :: Int -> Gen ClosedWellTyped
+rndExpr n = ClosedWellTyped <$> evalStateT genExpr (initEnv n)
+
+initEnv :: Int -> Env a
+initEnv n = Env [] $ map (pack . show) [1..n]
+
+extend :: Var -> Expr e -> GenExpr e ()
+extend x t = modify (\env -> env { bindings = (x,t) : bindings env })
+
+select :: [(Int,GenExprPair e,Env e -> Bool)] -> GenExprPair e
+select wgps = do
+    env <- get
+    join $ lift $ frequency $ foldr (\(w,g,prcd) wgs -> if prcd env 
+                                                        then (w,return g) : wgs
+                                                        else wgs) [] wgps
+
+scope :: GenExpr e a -> GenExpr e a
+scope f = get >>= lift . evalStateT f
+
+substUniq :: Text -> Expr a -> Expr a -> Expr a
+substUniq x e' e = case e of
+    Lam x' _A  b  -> Lam x' (substUniq x e' _A) (substUniq x e' b)
+    Pi  x' _A _B  -> Pi  x' (substUniq x e' _A) (substUniq x e' _B)
+    App f a       -> App (substUniq x e' f) (substUniq x e' a)
+    Var (V x' _) -> if x == x' then e' else e
+    Const k       -> Const k
+    Embed p       -> Embed p
+
+buildPi :: Text -> Expr e -> Expr e -> Expr e -> (Expr e,Expr e)
+buildPi x _M _N _Nt = (Pi x _M _N, _Nt)
+
+buildLambda :: Text -> Expr e -> Expr e -> Expr e -> (Expr e, Expr e)
+buildLambda x _M _N _Nt = (Lam x _M _N, Pi x _M _Nt)
+
+uniquesAvailable :: Env e -> Bool
+uniquesAvailable = not . null . uniques
+
+bindingOfAvailable :: Eq e => Expr e -> Env e -> Bool
+bindingOfAvailable t = any ((t ==) . snd) . bindings
+
+bindingsAvailable :: Env e -> Bool
+bindingsAvailable = not . null . bindings
+
+piFilter :: Eq e => Expr e -> Expr e -> Bool
+piFilter t (Pi _ _A _) = _A == t
+piFilter _ _           = False
+
+
+genExpr :: Eq e => GenExpr e (Expr e)
+genExpr = fst <$> select [ (20, genContext, const True)
+                         , (50, genLambda , uniquesAvailable)
+                         , (30, genApp    , \e -> length (uniques e) > 1)
+                         ]
+
+genObj :: Eq e => GenExprPair e
+genObj = select [ (5,  genObjPi , uniquesAvailable)
+                , (50, genLambda, uniquesAvailable)
+                , (25, genVar   , bindingsAvailable)
+                , (20, genApp   , \e -> (null (bindings e) && length (uniques e) > 1) 
+                                     || (bindingsAvailable e && uniquesAvailable e)
+                  )
+                ]
+
+genContext :: Eq e => GenExprPair e
+genContext = select [ (15, return (Const Star,Const Box), const True)
+                    , (20, genVarOf (Const Star)        , bindingOfAvailable (Const Star))
+                    , (15, genPi                        , uniquesAvailable)
+                    ]
+
+
+genVar :: Eq e => GenExprPair e
+genVar = genVarWith (const True)
+
+genVarOf :: Eq e => Expr e -> GenExprPair e
+genVarOf t = genVarWith (t ==)
+
+genPiVarOf :: Eq e => Expr e -> GenExprPair e
+genPiVarOf t = genVarWith (piFilter t)
+
+genVarWith :: Eq e => (Expr e -> Bool) -> GenExprPair e
+genVarWith f = do
+    bEnv' <- gets bindings
+    let bEnv = filter (f . snd) bEnv'
+    lift $ (\x -> (Var $ fst x, snd x)) A.<$> elements bEnv
+
+
+genPi :: Eq e => GenExprPair e
+genPi = genAbsWith (scope genContext) genContext buildPi
+
+genObjPi :: Eq e => GenExprPair e
+genObjPi = genAbsWith (scope genContext) genBody buildPi
+    where genBody = select [ (20, genVarOf (Const Star), bindingOfAvailable (Const Star))
+                           , (15, genObjPi             , uniquesAvailable)
+                           ]
+
+
+genLambda :: Eq e => GenExprPair e
+genLambda = genAbsWith (scope genContext) genObj buildLambda
+
+genLambdaOf :: Eq e => Expr e -> GenExprPair e
+genLambdaOf _M = genAbsWith (return (_M,Const Star)) genObj buildLambda
+
+
+genAbsWith :: GenExprPair e
+           -> GenExprPair e
+           -> (Text -> Expr e -> Expr e -> Expr e -> (Expr e,Expr e))
+           -> GenExprPair e
+genAbsWith gT gB build = do
+    st <- get
+    let (x:xs) = uniques st
+    put $ st { uniques = xs }
+    (_M,_) <- gT
+    extend (V x 0) _M
+    (_N,_Nt) <- gB
+    return $ build x _M _N _Nt
+
+genApp :: Eq e => GenExprPair e
+genApp = do
+    (_N, _A)      <- scope genObj
+    (f,Pi x _ _B) <- scope $ select [ (40, genLambdaOf _A, uniquesAvailable)
+                                    , (20, genPiVarOf  _A, any (piFilter _A . snd) . bindings)
+                                    ]
+    return (App f _N, substUniq x _N _B)

--- a/testsuite/Properties.hs
+++ b/testsuite/Properties.hs
@@ -1,0 +1,30 @@
+module Main (
+    main
+  ) where
+
+import Test.Tasty
+import Test.Tasty.QuickCheck as QC
+
+import Morte.Core
+import ClosedWellTyped
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Properties" [
+      QC.testProperty "normalize . normalize == normalize" normalizeIdempotent 
+    , QC.testProperty "Well typed after normalization"     wellTypedAfterNormalize
+    ]
+
+wellTypedAfterNormalize :: ClosedWellTyped -> Bool
+wellTypedAfterNormalize (ClosedWellTyped expr) = 
+        not (isRight $ typeOf expr) || (isRight $ typeOf $ normalize expr)
+
+normalizeIdempotent :: ClosedWellTyped -> Bool
+normalizeIdempotent (ClosedWellTyped expr) = normalize nExpr == nExpr
+    where nExpr = normalize expr
+
+isRight :: Either a b -> Bool
+isRight (Left  _) = False
+isRight (Right _) = True


### PR DESCRIPTION
The ``Arbitrary`` instance for ``Expr`` will generate closed well typed expression.
``App`` terms will not be generated as the *lhs* of an ``App``. This is because although generation 
speed is not a problem, or something I had to think about when implementing, it may become one when generating that kind of terms and I need to think things more.

There is not shrinking implemented either as I need to experiment with it a little bit more.