### PR TITLE
Relax binary upper bound to <9

### DIFF
--- a/morte.cabal
+++ b/morte.cabal
@@ -36,7 +36,7 @@ Library
     Build-Depends:
         base                 >= 4        && < 5   ,
         array                >= 0.4.0.0  && < 0.6 ,
-        binary               >= 0.7.0.0  && < 0.8 ,
+        binary               >= 0.7.0.0  && < 0.9 ,
         containers           >= 0.5.0.0  && < 0.6 ,
         deepseq              >= 1.3.0    && < 1.5 ,
         Earley               >= 0.10.1.0 && < 0.12,


### PR DESCRIPTION
Fixes the build with Stackage nightly.