### PR TITLE
Make `whnf` behave as intended on application

### DIFF
--- a/src/Morte/Core.hs
+++ b/src/Morte/Core.hs
@@ -587,7 +587,7 @@ whnf e = case e of
           where
             a' = shift 1 x a
             b' = subst x 0 a' b
-        _          -> e
+        f'         -> App f' a
     _       -> e
 
 -- | Returns whether a variable is free in an expression


### PR DESCRIPTION
I stumbled over this while comparing with how `bound` does things. Performance figures are rather mixed.